### PR TITLE
feat(starboard): add starboard plugin

### DIFF
--- a/plugins/starboard/commands/stars.ts
+++ b/plugins/starboard/commands/stars.ts
@@ -1,0 +1,120 @@
+import { Client} from 'discordx'
+import { SlashGroup, SlashOption } from '@decorators'
+import { Category } from '@discordx/utilities'
+import { ApplicationCommandOptionType, CommandInteraction, Channel } from 'discord.js'
+import { StarBoard, StarBoardMessage } from '../entities'
+import { Discord, Slash } from '@decorators'
+import { Guard, UserPermissions } from '@guards'
+import { injectable } from "tsyringe"
+import { Database } from '@services'
+import { wrap, assign } from "@mikro-orm/core"
+
+
+@Discord()
+@injectable()
+@Category('Admin')
+@SlashGroup({name: 'stars', localizationSource: 'StarBoard.STARBOARD.STAR_DESC'})
+@SlashGroup('stars')
+export default class StarsCommand {
+
+	constructor(
+        private db: Database
+    ) {}
+
+
+	@Slash({
+		name: "set",
+		localizationSource: 'StarBoard.STARBOARD.STAR_DESC',
+	})
+	@Guard(
+		UserPermissions(['Administrator'])
+	)
+	async set(
+		@SlashOption({
+			name: "channel",
+			localizationSource: 'StarBoard.STARBOARD.STAR_SET_CHAN',
+			required: false,
+			type: ApplicationCommandOptionType.Channel
+		})
+		channel: Channel,
+
+		@SlashOption({
+			name: "emoji",
+			localizationSource: 'StarBoard.STARBOARD.STAR_SET_EMOJI',
+			required: false,
+			type: ApplicationCommandOptionType.String
+		})
+		emoji: string,
+
+		@SlashOption({
+			name: "minstar",
+			localizationSource: 'StarBoard.STARBOARD.STAR_MIN_EMOJI',
+			required: false,
+			type: ApplicationCommandOptionType.Integer
+
+		})
+		minStar: number,
+
+		interaction: CommandInteraction,
+		client: Client,
+		{ localize }: InteractionData
+	) {
+		// Verifications
+		if(!interaction.guildId) return interaction.followUp({ content: localize.StarBoard.STARBOARD.STAR_ERR_GUILD.MESSAGE(), ephemeral: true });
+		if(!channel && !emoji && !minStar) return interaction.followUp({ content: localize.StarBoard.STARBOARD.STAR_ERR_PARAM.MESSAGE(), ephemeral: true });
+
+		// parse emoji
+		if(emoji) {
+			const parsed = /^<a?:[A-z]+:([0-9]+)>$/.exec(emoji.trim());
+			if(parsed && parsed.length === 2) emoji = parsed[1];
+			else {
+				if(/^\p{Extended_Pictographic}$/u.test(emoji.trim())) emoji = emoji.trim()
+				else interaction.followUp({ content: localize.StarBoard.STARBOARD.STAR_ERR_EMOJI.MESSAGE(), ephemeral: true });
+			}
+		}
+
+		// Fetch current config
+		const starRepo = this.db.get(StarBoard)
+		const starMessage = this.db.get(StarBoardMessage)
+		const chanStars = await starRepo.findOne({ guildId: interaction.guildId })
+
+		// If no config :
+		if(!chanStars) {
+			// If only emoji is provided :
+			if(!channel) return interaction.followUp({content: localize.StarBoard.STARBOARD.STAR_SLC_CHAN.MESSAGE(), ephemeral: true });
+
+			let starboard = new StarBoard()
+			starboard.guildId = interaction.guildId
+			starboard.channelId = channel.id
+			if(emoji) starboard.emoji = emoji
+			if(minStar) starboard.minStar = minStar
+
+			await starRepo.persistAndFlush(starboard)
+			this.db.em.clearCache("star_guild_" + interaction.guildId)
+			await interaction.followUp({
+				content: localize.StarBoard.STARBOARD.STAR_CHAN_SET.MESSAGE(),
+				ephemeral: true
+			})
+		} else {
+			// Update all previous starred messages
+			let previousMessages = await starMessage.find({ starboard: chanStars, starboardChannel: null })
+			if(previousMessages && previousMessages.length > 0) {
+				await starMessage.persistAndFlush(
+					previousMessages.map(el => wrap(el).assign({ starboardChannel: chanStars.channelId }))
+				)
+			}
+
+			// Update the starboard
+			if(emoji) chanStars.emoji = emoji
+			if(minStar) chanStars.minStar = minStar
+			if(channel) chanStars.channelId = channel.id
+
+			await starRepo.persistAndFlush(chanStars)
+			this.db.em.clearCache("star_guild_" + interaction.guildId)
+			await interaction.followUp({
+				content: localize.StarBoard.STARBOARD.STAR_CFG_UPDATED.MESSAGE(),
+				ephemeral: true
+			})
+		}
+	}
+}

--- a/plugins/starboard/entities/StarBoard.ts
+++ b/plugins/starboard/entities/StarBoard.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryKey, Property, EntityRepositoryType, OneToMany, IntegerType } from '@mikro-orm/core'
+import { EntityRepository } from '@mikro-orm/sqlite'
+
+import { CustomBaseEntity } from '@entities'
+
+// ===========================================
+// ================= Entity ==================
+// ===========================================
+
+@Entity({ customRepository: () => StarBoardRepository })
+export class StarBoard extends CustomBaseEntity {
+
+    [EntityRepositoryType]?: StarBoardRepository
+
+    @PrimaryKey({ autoincrement: false })
+    guildId!: string
+
+    @Property()
+    channelId!: string
+
+    @Property({default: '⭐'})
+    emoji!: string
+
+    @Property({ type: IntegerType })
+    minStar: number = 3
+}
+
+// ===========================================
+// =========== Custom Repository =============
+// ===========================================
+
+export class StarBoardRepository extends EntityRepository<StarBoard> { 
+
+}

--- a/plugins/starboard/entities/StarBoardMessage.ts
+++ b/plugins/starboard/entities/StarBoardMessage.ts
@@ -1,0 +1,39 @@
+import { Entity, PrimaryKey, Property, EntityRepositoryType, ManyToOne } from '@mikro-orm/core'
+import { EntityRepository } from '@mikro-orm/sqlite'
+
+import { CustomBaseEntity} from '@entities'
+import { StarBoard } from './StarBoard'
+
+// ===========================================
+// ================= Entity ==================
+// ===========================================
+
+@Entity({ customRepository: () => StarBoardMessageRepository })
+export class StarBoardMessage extends CustomBaseEntity {
+
+    [EntityRepositoryType]?: StarBoardMessageRepository
+
+    @PrimaryKey({ autoincrement: false })
+    srcMessage! :string
+    
+    @Property()
+    starboardMessage!: string
+    
+    @Property({ nullable: true })
+    starboardChannel?: string
+
+    @Property()
+    starCount!: number
+
+    @ManyToOne()
+    starboard: StarBoard
+
+}
+
+// ===========================================
+// =========== Custom Repository =============
+// ===========================================
+
+export class StarBoardMessageRepository extends EntityRepository<StarBoardMessage> { 
+
+}

--- a/plugins/starboard/entities/index.ts
+++ b/plugins/starboard/entities/index.ts
@@ -1,0 +1,2 @@
+export * from "./StarBoard"
+export * from "./StarBoardMessage"

--- a/plugins/starboard/events/custom/newStar.ts
+++ b/plugins/starboard/events/custom/newStar.ts
@@ -1,0 +1,89 @@
+import dayjs from 'dayjs'
+import { Client } from 'discordx'
+import { injectable } from 'tsyringe'
+import { Loaded } from "@mikro-orm/core"
+import { ButtonBuilder, ButtonStyle, EmbedBuilder, MessageReaction, PartialMessageReaction, TextChannel } from 'discord.js'
+
+import { Discord, OnCustom } from '@decorators'
+import { Database } from '@services'
+import { StarBoard, StarBoardMessage } from '../../entities'
+
+@Discord()
+@injectable()
+export default class newStarEvent {
+
+    constructor(
+        private client: Client,
+        private db: Database,  
+    ) {}
+
+    @OnCustom('newStar')
+    async newStarHandler(
+        starMessage: Loaded<StarBoardMessage, never>,
+        reaction: MessageReaction | PartialMessageReaction,
+        chanStars: Loaded<StarBoard, never>
+    ) {
+        const starboardRepo = this.db.get(StarBoard)
+        const starMessageRepo = this.db.get(StarBoardMessage)
+
+
+        // define image
+        let image = ""
+        if (reaction.message.attachments.size > 0) {
+            image = reaction.message.attachments.first()!.url
+        }
+
+        //checks if the message has an image
+        if (reaction.message.embeds.length > 0) {
+            if (reaction.message.embeds[0].image) {
+                image = reaction.message.embeds[0].image.url
+            }
+        }
+
+        let embed = new EmbedBuilder()
+            .setAuthor({
+                name: reaction.message.author!.username + "#" + reaction.message.author!.discriminator,
+                iconURL: reaction.message.author!.avatarURL()!
+            })
+            .setColor("#FFD700")
+            .setFooter({
+                text: dayjs(reaction.message.createdAt).format("DD/MM/YYYY HH:mm"),
+            })
+        
+        // Adds an image if there is one
+        if(image) embed = embed.setImage(image)
+
+        // Adds the message content if there is one
+        if(reaction.message.content) embed = embed.setDescription(reaction.message.content)
+
+        const btn = new ButtonBuilder()
+            .setLabel("Original Message")
+            .setStyle(ButtonStyle.Link)
+            .setURL(reaction.message.url)
+
+        // TODO : Fix with discord.js update 
+        // const row = new ActionRowBuilder().addComponents(btn)
+        
+        const guild = await this.client.guilds.fetch(chanStars.guildId)
+        const channel = await guild.channels.fetch(chanStars.channelId) as TextChannel
+
+        const newStarMessageDiscord = await channel.send({
+            content: reaction.emoji.toString() + " " + reaction.message.reactions.cache.get(chanStars.emoji)!.count + " | " + reaction.message.channel.toString(),
+            embeds: [embed],
+            components: [{
+                type: 1,
+                components: [
+                    btn
+                ]
+            }]
+        })
+
+        let newStarMessage = new StarBoardMessage()
+        newStarMessage.srcMessage = reaction.message.id
+        newStarMessage.starboardMessage = newStarMessageDiscord.id
+        newStarMessage.starCount = reaction.message.reactions.cache.get(chanStars.emoji)!.count
+        newStarMessage.starboard = chanStars
+        await starMessageRepo.persistAndFlush(newStarMessage)
+        this.db.em.clearCache("star_message_" + reaction.message.id)
+    }
+}

--- a/plugins/starboard/events/custom/updateStar.ts
+++ b/plugins/starboard/events/custom/updateStar.ts
@@ -1,0 +1,56 @@
+import { Client } from 'discordx'
+import { injectable } from 'tsyringe'
+import { Loaded } from "@mikro-orm/core"
+import { MessageReaction, PartialMessageReaction, TextChannel } from "discord.js"
+
+import { Database } from '@services'
+import { Discord, OnCustom } from '@decorators'
+import { StarBoard, StarBoardMessage } from '../../entities'
+
+@Discord()
+@injectable()
+export default class updateStarEvent {
+
+    constructor(
+        private client: Client,
+        private db: Database,  
+    ) {}
+
+    @OnCustom('updateStar')
+    async updateStarHandler(
+        starMessage: Loaded<StarBoardMessage, never>,
+        reaction: MessageReaction | PartialMessageReaction,
+        chanStars: Loaded<StarBoard, never>
+    ) {
+        const starboardRepo = this.db.get(StarBoard)
+        const starMessageRepo = this.db.get(StarBoardMessage)
+
+        const guild = await this.client.guilds.fetch(chanStars.guildId)
+        const channel = await guild.channels.fetch(starMessage.starboardChannel ?? chanStars.channelId) as TextChannel
+        const message = await channel.messages.fetch(starMessage.starboardMessage)
+
+        if(starMessage.starboardChannel && starMessage.starboardChannel !== chanStars.channelId) {
+            const newChannel = await guild.channels.fetch(chanStars.channelId) as TextChannel
+
+            const newMessage = await newChannel.send({
+                content: reaction.emoji.toString() + " " + reaction.message.reactions.cache.get(chanStars.emoji)!.count + " | " + reaction.message.channel.toString(),
+                embeds: [message.embeds[0]]
+            })
+
+            starMessage.starCount = reaction.message.reactions.cache.get(chanStars.emoji)!.count
+            starMessage.starboardMessage = newMessage.id
+            starMessage.starboardChannel = undefined
+        } else {
+            await message.edit({
+                content: reaction.emoji.toString() + " " + reaction.message.reactions.cache.get(chanStars.emoji)!.count + " | " + reaction.message.channel.toString(),
+                embeds: [message.embeds[0]]
+            })
+    
+            starMessage.starCount = reaction.message.reactions.cache.get(chanStars.emoji)!.count
+        }
+
+        await starMessageRepo.persistAndFlush(starMessage)
+        this.db.em.clearCache("star_message_" + reaction.message.id)
+    }
+
+}

--- a/plugins/starboard/events/messageReactionAdd.ts
+++ b/plugins/starboard/events/messageReactionAdd.ts
@@ -1,0 +1,50 @@
+import { injectable } from "tsyringe";
+import { Client, ArgsOf } from "discordx"
+
+import { Discord, On } from "@decorators"
+import { Database, EventManager } from "@services"
+import { resolveDependency } from "@utils/functions"
+import { StarBoard, StarBoardMessage } from "../entities"
+
+@Discord()
+@injectable()
+export default class messageReactionAddEvent {
+
+    constructor(
+        private eventManager: EventManager
+    ) { }
+
+    @On('messageReactionAdd')
+    async messageReactionAddHandler(
+        [reaction, user]: ArgsOf<"messageReactionAdd">,
+        client: Client
+    ) {
+
+        // Using partial to get older messages
+        if (reaction.message.partial) await reaction.message.fetch()
+        // Resolve entities repository
+        const db = await resolveDependency(Database)
+        const starboardRepo = db.get(StarBoard)
+        const starMessageRepo = db.get(StarBoardMessage)
+        // Check if GuildId exists in the DB
+        const chanStars = await starboardRepo.findOne({ guildId: reaction.message.guildId }, { cache: ["star_guild_" + reaction.message.guildId, 60_1000] }) // 1 minute
+        if (!chanStars) return
+        // Check if starred message is in the starboard channel
+        if (chanStars && chanStars.channelId === reaction.message.channelId) return
+        // If the reaction is different than the guild emoji, then return.
+        if ((reaction.emoji.id ?? reaction.emoji.toString()) !== chanStars.emoji) return
+        // Set the minimum reactions needed
+        if (reaction.message.reactions.cache.get(chanStars.emoji)!.count < chanStars.minStar) return
+        // Check if the message is already in the StarBoard channel
+        const starMessage = await starMessageRepo.findOne({ srcMessage: reaction.message.id }, { cache: ["star_message_" + reaction.message.id, 60_1000] }) // 1 minute
+        // If the message is not in the StarBoard channel, then create a new one
+        if (!starMessage) {
+            this.eventManager.emit("newStar", starMessage, reaction, chanStars)
+        }
+
+        // If the message is in the StarBoard channel and the count changed, then update it
+        else if (starMessage.starCount < reaction.message.reactions.cache.get(chanStars.emoji)!.count) {
+            this.eventManager.emit("updateStar", starMessage, reaction, chanStars)
+        }
+    }
+}

--- a/plugins/starboard/i18n/en.ts
+++ b/plugins/starboard/i18n/en.ts
@@ -1,0 +1,43 @@
+/* eslint-disable */
+import type { BaseTranslation } from '@i18n'
+
+const en = {
+    STARBOARD: {
+        STAR_SLC_CHAN: {
+            MESSAGE: 'Please select a channel first !'
+        },
+        STAR_CHAN_SET: {
+            MESSAGE: 'Starboard channel set!'
+        },
+        STAR_CFG_UPDATED: {
+            MESSAGE: 'Starboard config updated !'
+
+        },
+        STAR_ERR_EMOJI: {
+            MESSAGE: 'Please provide a correct emoji (please do not use combined emoji) !'
+        },
+        STAR_ERR_PARAM: {
+            MESSAGE: 'Please provide at least one parameter !'
+        },
+        STAR_ERR_GUILD: {
+            MESSAGE: 'This command must be use inside a guild !'
+        },
+        STAR_MIN_EMOJI: {
+            DESCRIPTION: 'Set the minimum number of stars to be displayed'
+        },
+        STAR_SET_EMOJI: {
+            DESCRIPTION: 'Set the emoji to use for the starboard'
+        },
+        STAR_SET_CHAN: {
+            DESCRIPTION: 'Set the channel to use for the starboard'
+        },
+
+        STAR_DESC: {
+            DESCRIPTION: 'Set the starboard channel'
+        },
+
+    },
+
+} satisfies BaseTranslation
+
+export default en

--- a/plugins/starboard/i18n/fr.ts
+++ b/plugins/starboard/i18n/fr.ts
@@ -1,0 +1,41 @@
+/* eslint-disable */
+import type { BaseTranslation } from '@i18n'
+
+const fr = {
+    STARBOARD: {
+        STAR_SLC_CHAN: {
+            MESSAGE: 'Merci de d\'abord choisir un channel!'
+        },
+        STAR_CHAN_SET: {
+            MESSAGE: 'Le channel starboard a été configuré!'
+        },
+        STAR_CFG_UPDATED: {
+            MESSAGE: 'La configuration du starboard a été mise à jour !'
+
+        },
+        STAR_ERR_EMOJI: {
+            MESSAGE: 'Merci de renseigner un emoji valide (n\'utilisez pas les emojis combinés) !'
+        },
+        STAR_ERR_PARAM: {
+            MESSAGE: 'Merci de choisir au minimum un paramètre!'
+        },
+        STAR_ERR_GUILD: {
+            MESSAGE: 'Cette commande doit être utilisée dans un serveur !'
+        },
+        STAR_MIN_EMOJI: {
+            DESCRIPTION: 'Définissez le nombre minimum d\'étoiles à afficher'
+        },
+        STAR_SET_EMOJI: {
+            DESCRIPTION: 'Définissez l\'emoji à utiliser pour le starboard'
+        },
+        STAR_SET_CHAN: {
+            DESCRIPTION: 'Définissez le channel à utiliser pour le starboard'
+        },
+        STAR_DESC: {
+            DESCRIPTION: 'Paramétrez le starboard'
+        },
+
+    },
+} satisfies BaseTranslation
+
+export default fr

--- a/plugins/starboard/main.ts
+++ b/plugins/starboard/main.ts
@@ -1,0 +1,12 @@
+import { clientConfig } from "../../client"
+import { GatewayIntentBits, Partials } from "discord.js"
+
+// Check partials
+if(!clientConfig.partials.includes(Partials.Channel)) throw new Error("You must enable the Channel partial to use this plugin !")
+if(!clientConfig.partials.includes(Partials.Message)) throw new Error("You must enable the Message partial to use this plugin !")
+if(!clientConfig.partials.includes(Partials.Reaction)) throw new Error("You must enable the Reaction partial to use this plugin !")
+
+// Check intents
+if(!clientConfig.intents.includes(GatewayIntentBits.GuildMessages)) throw new Error("You must enable the GuildMessages intent to use this plugin !")
+if(!clientConfig.intents.includes(GatewayIntentBits.MessageContent)) throw new Error("You must enable the MessageContent intent to use this plugin !")
+if(!clientConfig.intents.includes(GatewayIntentBits.GuildMessageReactions)) throw new Error("You must enable the GuildMessageReactions intent to use this plugin !")

--- a/plugins/starboard/plugin.json
+++ b/plugins/starboard/plugin.json
@@ -1,0 +1,7 @@
+{
+    "author": "Sykho",
+    "name": "StarBoard",
+    "version": "1.0.0",
+    "tscordRequiredVersion": ">=2.2",
+    "description": "Get a new StarBoard to your discord server!"
+}


### PR DESCRIPTION
## Type of pull request

- [X] New plugin submission
- [ ] Update a plugin
- [ ] Delete a plugin
- [ ] Other

## Plugin info
StarBoard plugin let you configure your own starboard for your discord server.
You can set the minimum emoji needed to add a message to the starboard, set a custom emoji and set the starboard channel!
<br>

| Name        | Version |
|-------------|---------|
| StarBoard | 1.0.0 |

## Description or changelog

```

```

## Notes